### PR TITLE
Remove unused dependencies

### DIFF
--- a/scheme2c-compatibility.egg
+++ b/scheme2c-compatibility.egg
@@ -6,7 +6,6 @@
  (license "LGPL")
  (synopsis "Scheme->c compatibility package")
  (dependencies srfi-1 srfi-13 srfi-14 traversal foreigners xlib)
- (test-dependencies test)
  (components (extension scheme2c-compatibility
                         (types-file)
                         (inline-file)

--- a/scheme2c-compatibility.meta
+++ b/scheme2c-compatibility.meta
@@ -6,9 +6,7 @@
  (maintainer "Andrei Barbu")
  (license "LGPL")
  (synopsis "Scheme->c compatibility package")
- (depends setup-helper miscmacros check-errors condition-utils
-          foreigners xlib traversal)
- (test-depends test)
+ (depends setup-helper foreigners xlib traversal)
  (files "scheme2c-compatibility.meta" 
         "scheme2c-compatibility.release-info"
         "scheme2c-compatibility.scm" 


### PR DESCRIPTION
* The egg has no test suite, so the test dependency on the `test` egg
  is not necessary.

* The `miscmacros`, `check-errors` and `condition-utils` eggs are not
  used in this repository, so they are not needed as dependencies.